### PR TITLE
Heading Links

### DIFF
--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}">🔗</a></h{{ .Level }}>

--- a/static/css/link-style.css
+++ b/static/css/link-style.css
@@ -1,3 +1,7 @@
 article a {
   text-decoration: underline;
 }
+
+h1 a, h2 a, h3 a, h4 a, h5 a, h6 a {
+  text-decoration: none;
+}


### PR DESCRIPTION
This modifies the h1-h6 header elements so that a link appears next to
them that may be used to directly link to that heading section within a
post.